### PR TITLE
Drop python 2 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: 
-          - '2.7'
+          - '3.6'
+          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'

--- a/docs_src/installation.rst
+++ b/docs_src/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-cxroots uses the Python_ programming language and is compatible with both Python 2 and 3.
+cxroots uses the Python_ programming language and requires Python 3.6 or later.
 
 With Python installed the easiest way to install cxroots, along with its dependencies, is using the Python Package Index (PyPi) by running on the command line::
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,12 @@
 # cxroots as a library.
 #
 
+scipy; python_version < '3.8' # pyup: ignore
+numpy; python_version < '3.8' # pyup: ignore
+numpydoc; python_version < '3.8' # pyup: ignore
+matplotlib; python_version < '3.8' # pyup: ignore
+pytest; python_version < '3.8' # pyup: ignore
+
 scipy==1.8.0; python_version >= '3.8'
 numpy==1.22.3; python_version >= '3.8'
 numpydoc==1.2.1; python_version >= '3.8'

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,12 +9,13 @@
 scipy; python_version < '3.8' # pyup: ignore
 numpy; python_version < '3.8' # pyup: ignore
 numpydoc; python_version < '3.8' # pyup: ignore
+matplotlib; python_version < '3.8' # pyup: ignore
 
 scipy==1.8.0; python_version >= '3.8'
 numpy==1.22.3; python_version >= '3.8'
 numpydoc==1.2.1; python_version >= '3.8'
 mpmath==1.2.1
 numdifftools==0.9.40
-matplotlib==3.5.1
+matplotlib==3.5.1; python_version >= '3.8'
 pytest==7.1.2
 pytest-xdist==2.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ scipy; python_version < '3.8' # pyup: ignore
 numpy; python_version < '3.8' # pyup: ignore
 numpydoc; python_version < '3.8' # pyup: ignore
 matplotlib; python_version < '3.8' # pyup: ignore
+pytest; python_version < '3.8' # pyup: ignore
 
 scipy==1.8.0; python_version >= '3.8'
 numpy==1.22.3; python_version >= '3.8'
@@ -17,5 +18,5 @@ numpydoc==1.2.1; python_version >= '3.8'
 mpmath==1.2.1
 numdifftools==0.9.40
 matplotlib==3.5.1; python_version >= '3.8'
-pytest==7.1.2
+pytest==7.1.2; python_version >= '3.8'
 pytest-xdist==2.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,12 +6,6 @@
 # cxroots as a library.
 #
 
-scipy; python_version < '3.8' # pyup: ignore
-numpy; python_version < '3.8' # pyup: ignore
-numpydoc; python_version < '3.8' # pyup: ignore
-matplotlib; python_version < '3.8' # pyup: ignore
-pytest; python_version < '3.8' # pyup: ignore
-
 scipy==1.8.0; python_version >= '3.8'
 numpy==1.22.3; python_version >= '3.8'
 numpydoc==1.2.1; python_version >= '3.8'

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,10 +8,11 @@
 
 scipy; python_version < '3.8' # pyup: ignore
 numpy; python_version < '3.8' # pyup: ignore
+numpydoc; python_version < '3.8' # pyup: ignore
 
 scipy==1.8.0; python_version >= '3.8'
 numpy==1.22.3; python_version >= '3.8'
-numpydoc==1.2.1
+numpydoc==1.2.1; python_version >= '3.8'
 mpmath==1.2.1
 numdifftools==0.9.40
 matplotlib==3.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,10 @@
 #
 
 scipy; python_version < '3.8' # pyup: ignore
-scipy==1.8.0; python_version >= '3.8'
+numpy; python_version < '3.8' # pyup: ignore
 
-numpy==1.22.3
+scipy==1.8.0; python_version >= '3.8'
+numpy==1.22.3; python_version >= '3.8'
 numpydoc==1.2.1
 mpmath==1.2.1
 numdifftools==0.9.40

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,25 +6,11 @@
 # cxroots as a library.
 #
 
-scipy==1.8.0; python_version > '2.7'
-scipy==1.2.1; python_version <= '2.7'  # pyup: ignore
-
-numpy==1.22.3; python_version > '2.7'
-numpy==1.16.4; python_version <= '2.7'  # pyup: ignore
-
-numpydoc==1.2.1; python_version > '2.7'
-numpydoc==0.9.2; python_version <= '2.7'  # pyup: ignore
-
-mpmath==1.2.1; python_version > '2.7'
-mpmath==1.1.0; python_version <= '2.7'  # pyup: ignore
-
+scipy==1.8.0
+numpy==1.22.3
+numpydoc==1.2.1
+mpmath==1.2.1
 numdifftools==0.9.40
-
-matplotlib==3.5.1; python_version > '2.7'
-matplotlib==2.2.3; python_version <= '2.7'  # pyup: ignore
-
-pytest==7.1.2; python_version > '2.7'
-pytest==4.6.4; python_version <= '2.7'  # pyup: ignore
-
-pytest-xdist==2.5.0; python_version > '2.7'
-pytest-xdist==1.34.0; python_version <= '2.7' # pyup: ignore
+matplotlib==3.5.1
+pytest==7.1.2
+pytest-xdist==2.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,9 @@
 # cxroots as a library.
 #
 
-scipy==1.8.0
+scipy; python_version < '3.8' # pyup: ignore
+scipy==1.8.0; python_version >= '3.8'
+
 numpy==1.22.3
 numpydoc==1.2.1
 mpmath==1.2.1

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     packages=packages,
     zip_safe=False,  # prevent cxroots from installing as a .egg zip file
     platforms=["all"],
+    python_requires=">=3.6",
     setup_requires=["pytest-runner"],
     install_requires=["numpy", "scipy", "numpydoc", "mpmath", "numdifftools>=0.9.39"],
     tests_require=["pytest"],
@@ -35,7 +36,6 @@ setup(
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering :: Mathematics",
         "License :: OSI Approved :: BSD License",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setup(
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering :: Mathematics",
         "License :: OSI Approved :: BSD License",
-        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
     ],
 )


### PR DESCRIPTION
Rich is needed for https://github.com/rparini/cxroots/pull/133 but it is not available for python 2.  Python 2 reached End of Life on 1st Jan 2020 so no one should use it all anyway! 