### PR TITLE
Add "plot" install option to install matplotlib

### DIFF
--- a/docs_src/installation.rst
+++ b/docs_src/installation.rst
@@ -3,10 +3,12 @@ Installation
 
 cxroots uses the Python_ programming language and is compatible with both Python 2 and 3.
 
-With Python installed the easiest way to install cxroots, along with its dependencies, is using the Python Package Index (PyPi) by running on the command line::
+With Python installed the easiest way to install cxroots, along with its required dependencies, is using the Python Package Index (PyPi) by running on the command line::
 
 	pip install cxroots
 
+cxroots also has the capability to produce plots showing the roots and contours, however, this requires additional dependencies which can be installed with::
 
+	pip install cxroots[plot]
 
 .. _Python: http://www.python.org/

--- a/docs_src/tutorial.rst
+++ b/docs_src/tutorial.rst
@@ -43,7 +43,9 @@ For example, to define a rectangle whose verticies are the points :math:`0, i, 2
 To check that this is what we want we can plot this contour:
 
 .. note::
-	Getting cxroots to plot roots and contours requires additional optional dependencies that can be installed with `pip install cxroots[plot]`
+	Getting cxroots to plot roots and contours requires additional optional dependencies that can be installed with::
+		
+		pip install cxroots[plot]
 
 .. code-block:: python
 

--- a/docs_src/tutorial.rst
+++ b/docs_src/tutorial.rst
@@ -40,7 +40,10 @@ For example, to define a rectangle whose verticies are the points :math:`0, i, 2
 	from cxroots import Rectangle
 	rect = Rectangle([0,2], [0,1])
 
-To check that this is what we want we can plot this contour using matplotlib:
+To check that this is what we want we can plot this contour:
+
+.. note::
+	Getting cxroots to plot roots and contours requires additional optional dependencies that can be installed with `pip install cxroots[plot]`
 
 .. code-block:: python
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     setup_requires=["pytest-runner"],
     install_requires=["numpy", "scipy", "numpydoc", "mpmath", "numdifftools>=0.9.39"],
     tests_require=["pytest"],
+    extras_require={"plot": ["matplotlib"]},
     keywords="roots zeros complex analytic functions",
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Matplotlib is required for plotting (like the `.show()` methods) but not required to run the fundemental rootfinding algorithms