### PR TITLE
Fix _quad_prod not adding integral segments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
     - name: Test with pytest
-      run: pytest -v -n 2 --durations=10 -m 'not slow'
+      run: pytest -v -n 2 --durations=10 -m 'not slow' -x
 
 #   document:
 #     runs-on: ubuntu-latest

--- a/cxroots/root_counting.py
+++ b/cxroots/root_counting.py
@@ -222,9 +222,11 @@ def _quad_prod(
                 integrand_cache[t] = i
             return i
 
-        integral, err = integrate_quad_complex(
+        segment_integral, segment_err = integrate_quad_complex(
             integrand, 0, 1, epsabs=abs_tol, epsrel=rel_tol
         )
+        integral += segment_integral
+        err += segment_err
 
     return integral, abs(err)
 


### PR DESCRIPTION
Introduced by https://github.com/rparini/cxroots/pull/173

Tests were hanging but I thought that was just some Actions bug, turns out I broke something.