### PR TITLE
Remove `from __future__ import division`

### DIFF
--- a/cxroots/contours/annulus_sector.py
+++ b/cxroots/contours/annulus_sector.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from math import pi
 
 import numpy as np

--- a/cxroots/iterative_methods.py
+++ b/cxroots/iterative_methods.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import logging
 
 from numpy import inf

--- a/cxroots/root_approximation.py
+++ b/cxroots/root_approximation.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import functools
 import logging
 

--- a/cxroots/root_counting.py
+++ b/cxroots/root_counting.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import logging
 import warnings
 from math import inf, pi

--- a/cxroots/root_finding.py
+++ b/cxroots/root_finding.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import functools
 import logging
 import warnings

--- a/cxroots/root_finding_demo.py
+++ b/cxroots/root_finding_demo.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import numpy as np
 
 from .root_finding import find_roots_gen

--- a/cxroots/root_result.py
+++ b/cxroots/root_result.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from collections import namedtuple
 
 import numpy as np


### PR DESCRIPTION
We now require python > 3.6 in the setup.py so `from __future__ import division` is no longer needed