### PR TITLE
Subdivide contour when invalid approximate multiplicities are encountered

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 2.1.0 - 27/Dec/2023
+
+- Improved reliability by subdividing contours that produce invalid approximations for multiplicites, rather than ignoring the individual invalid approximations.
+
 ### 2.0.1 - 29/Aug/2023
 
 - Record in setup.py that only numpy < 1.25 will work with cxroots currently (https://github.com/rparini/cxroots/issues/285) 

--- a/cxroots/root_approximation.py
+++ b/cxroots/root_approximation.py
@@ -237,6 +237,6 @@ def approximate_roots(
     # print('n?', np.linalg.matrix_rank(HN, tol=1e-10))
 
     logger.debug(
-        "Approximate (roots, multiplicities): " + str(zip(roots, multiplicities))
+        f"Approximate (roots, multiplicities): {list(zip(roots, multiplicities))}"
     )
     return tuple(roots), tuple(multiplicities)

--- a/cxroots/root_finding.py
+++ b/cxroots/root_finding.py
@@ -489,19 +489,23 @@ def find_roots_gen(
                 contours.append(contour)
             continue
 
-        for approx_root, approx_multiplicity in list(
-            zip(approx_roots, approx_multiplicities)
+        if any(
+            abs(round(m.real) - m.real) > integer_tol
+            or abs(m.imag) > integer_tol
+            or m < 1
+            for m in approx_multiplicities
         ):
-            # check that the multiplicity is close to an integer
-            multiplicity = round(approx_multiplicity.real)
-            if (
-                abs(multiplicity - approx_multiplicity.real) > integer_tol
-                or abs(approx_multiplicity.imag) > integer_tol
-                or multiplicity < 1
-            ):
-                continue
+            logger.debug(
+                f"Subdividing due to invalid multiplicies: {approx_multiplicities}"
+            )
+            subdivide(contour)
+            continue
 
+        for approx_root, approx_multiplicity in zip(
+            approx_roots, approx_multiplicities
+        ):
             # attempt to refine the root
+            multiplicity = round(approx_multiplicity.real)
             root = iterate_to_root(
                 approx_root,
                 f,

--- a/cxroots/tests/test_rootfinding.py
+++ b/cxroots/tests/test_rootfinding.py
@@ -403,23 +403,23 @@ def test_rootfinding_299():
     there should have been.
     """
     # Geometry Details
-    l = 1.0
+    l = 1.0  # noqa: E741
     a = 0.25
     b = l - a
 
     # Region 1 (unburnt gas)
-    T1 = 300
-    P1 = 101325
-    R = 287.0  # Gas constant
+    T1 = 300  # noqa: N806
+    P1 = 101325  # noqa: N806
+    R = 287.0  # noqa: N806 Gas constant
     rho1 = P1 / (R * T1)  # Density of the unburnt gas (kg/m3)
     gamma = 1.4
-    C1 = np.sqrt(gamma * R * T1)  # Speed of sound
+    C1 = np.sqrt(gamma * R * T1)  # noqa: N806 Speed of sound
 
     # Region 2 (burnt gas)
-    T2 = 1200
-    P2 = P1
+    T2 = 1200  # noqa: N806
+    P2 = P1  # noqa: N806
     rho2 = P2 / (R * T2)
-    C2 = np.sqrt(gamma * R * T2)
+    C2 = np.sqrt(gamma * R * T2)  # noqa: N806
 
     zeta = rho1 * C1 / (rho2 * C2)
 

--- a/cxroots/tests/test_rootfinding.py
+++ b/cxroots/tests/test_rootfinding.py
@@ -9,6 +9,7 @@ References
     Springer 2000
 """
 
+import cmath
 import unittest
 
 import numpy as np
@@ -393,6 +394,76 @@ def test_df(int_method):
 
     assert roots.roots == pytest.approx([0.5])
     assert roots.multiplicities == [2]
+
+
+def test_rootfinding_299():
+    """
+    Regression test for https://github.com/rparini/cxroots/issues/299
+    In this case there were some roots missing and some with more multiplicites than
+    there should have been.
+    """
+    # Geometry Details
+    l = 1.0
+    a = 0.25
+    b = l - a
+
+    # Region 1 (unburnt gas)
+    T1 = 300
+    P1 = 101325
+    R = 287.0  # Gas constant
+    rho1 = P1 / (R * T1)  # Density of the unburnt gas (kg/m3)
+    gamma = 1.4
+    C1 = np.sqrt(gamma * R * T1)  # Speed of sound
+
+    # Region 2 (burnt gas)
+    T2 = 1200
+    P2 = P1
+    rho2 = P2 / (R * T2)
+    C2 = np.sqrt(gamma * R * T2)
+
+    zeta = rho1 * C1 / (rho2 * C2)
+
+    # Crocco's n-tau model
+    n = 10.0
+    tau = 0.005
+
+    def f(omega):
+        return zeta * cmath.cos(omega / C1 * a) * cmath.cos(omega / C2 * b) - (
+            1 + n * cmath.exp(1j * omega * tau)
+        ) * (cmath.sin(omega / C1 * a) * cmath.sin(omega / C2 * b))
+
+    def f_prime(omega):  # Derivative of f
+        return (
+            -zeta
+            * (
+                b / C2 * cmath.cos(omega * a / C1) * cmath.sin(omega * b / C2)
+                + a / C1 * cmath.cos(omega * b / C2) * cmath.sin(omega * a / C1)
+            )
+            - (1 + n * cmath.exp(1j * omega * tau))
+            * (
+                b / C2 * cmath.sin(omega * a / C1) * cmath.cos(omega * b / C2)
+                + a / C1 * cmath.sin(omega * b / C2) * cmath.cos(omega * a / C1)
+            )
+            - (1j * n * tau * cmath.exp(1j * omega * tau))
+            * (cmath.sin(omega * a / C1) * cmath.sin(omega * b / C2))
+        )
+
+    # Using a rectangle as the contour
+    contour = Rectangle([0, 5000], [-500, 500])
+    roots, multiplicities = contour.roots(f, f_prime)
+    roots = sorted(roots, key=lambda r: r.real)
+
+    expected_roots = [
+        261.045540365941 - 181.036716404397j,
+        904.889245400156 + 343.599454434591j,
+        1880.005303030232 + 388.327867463358j,
+        2801.720372617268 + 150.680161943082j,
+        3112.682726748578 + 47.264321292923j,
+        4362.901996620711 + 0.000000000000j,
+        4398.645160420987 + 184.305444695056j,
+    ]
+    assert all(m == 1 for m in multiplicities)
+    assert roots == pytest.approx(expected_roots)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolves #299 by subdividing a contour that produces invalid approximations for multiplicities, rather than ignoring the individual invalid approximations. 

In the case of #299 the presence of roots with multiplicities equal to 0 coincided with other roots having incorrect multiplicities so it seems sensible to treat an invalid approximate multiplicity as a sign that the approximation routine as a whole has not worked properly for this contour and that cxroots should subdivide the contour further to hopefully get a more accurate answer.