### PR TITLE
Temporarily require numpy<2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 3.0.1 - 23/Jul/2024
+
+- Temporarily require numpy<2
+
 ### 3.0.0 - 23/Jul/2024
 
 - Removed `df_approx_order` parameter

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     python_requires=">=3.8",
     setup_requires=["pytest-runner"],
     install_requires=[
-        "numpy",
+        "numpy<2",
         "scipy",
         "numpydoc",
         "mpmath",


### PR DESCRIPTION
The v3.0.0 version of cxroots is unfortunately not compatible with numpy v2 so pin in setup.py until #378 is resolved