### PR TITLE
Fix compatibility with numpy 2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ### 3.0.2 - 27/Jul/2024
 
-- Change types for compatibility with numpy 2
+- Adds compatibility with numpy v2 by replacing deprecated types (thanks [@MartinCapraro](https://github.com/MartinCapraro))
 
 ### 3.0.1 - 23/Jul/2024
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 3.0.2 - 27/Jul/2024
+
+- Change types for compatibility with numpy 2
+
 ### 3.0.1 - 23/Jul/2024
 
 - Temporarily require numpy<2

--- a/cxroots/contour.py
+++ b/cxroots/contour.py
@@ -45,11 +45,11 @@ class Contour(ContourABC):
     def __call__(self, t: float) -> complex: ...
 
     @overload
-    def __call__(self, t: npt.NDArray[np.float_]) -> npt.NDArray[np.complex_]: ...
+    def __call__(self, t: npt.NDArray[np.float64]) -> npt.NDArray[np.complex128]: ...
 
     def __call__(
-        self, t: float | npt.NDArray[np.float_]
-    ) -> complex | npt.NDArray[np.complex_]:
+        self, t: float | npt.NDArray[np.float64]
+    ) -> complex | npt.NDArray[np.complex128]:
         r"""
         The point on the contour corresponding the value of the
         parameter t.
@@ -75,7 +75,7 @@ class Contour(ContourABC):
         >>> c(0) == c(1)
         True
         """
-        t = np.array(t, dtype=np.float_)
+        t = np.array(t, dtype=np.float64)
         num_segments = len(self.segments)
         segment_index = np.array(num_segments * t, dtype=int)
         segment_index = np.mod(segment_index, num_segments)

--- a/cxroots/derivative.py
+++ b/cxroots/derivative.py
@@ -13,7 +13,7 @@ def central_diff(
 
     @overload
     def df(
-        z: npt.NDArray[np.complex_] | npt.NDArray[np.float_],
+        z: npt.NDArray[np.complex128] | npt.NDArray[np.float64],
     ) -> ComplexScalarOrArray: ...
 
     @overload

--- a/cxroots/paths.py
+++ b/cxroots/paths.py
@@ -27,11 +27,11 @@ class ComplexPath:
     def __call__(self, t: float) -> complex: ...
 
     @overload
-    def __call__(self, t: npt.NDArray[np.float_]) -> npt.NDArray[np.complex_]: ...
+    def __call__(self, t: npt.NDArray[np.float64]) -> npt.NDArray[np.complex128]: ...
 
     def __call__(
-        self, t: float | npt.NDArray[np.float_]
-    ) -> complex | npt.NDArray[np.complex_]:
+        self, t: float | npt.NDArray[np.float64]
+    ) -> complex | npt.NDArray[np.complex128]:
         r"""
         The parameterization of the path in the varaible :math:`t\in[0,1]`.
 
@@ -51,11 +51,11 @@ class ComplexPath:
     def dzdt(self, t: float) -> complex: ...
 
     @overload
-    def dzdt(self, t: npt.NDArray[np.float_]) -> npt.NDArray[np.complex_]: ...
+    def dzdt(self, t: npt.NDArray[np.float64]) -> npt.NDArray[np.complex128]: ...
 
     def dzdt(
-        self, t: float | npt.NDArray[np.float_]
-    ) -> complex | npt.NDArray[np.complex_]:
+        self, t: float | npt.NDArray[np.float64]
+    ) -> complex | npt.NDArray[np.complex128]:
         """
         The derivative of the parameterised curve in the complex plane, z, with
         respect to the parameterization parameter, t.
@@ -341,11 +341,11 @@ class ComplexLine(ComplexPath):
     def __call__(self, t: float) -> complex: ...
 
     @overload
-    def __call__(self, t: npt.NDArray[np.float_]) -> npt.NDArray[np.complex_]: ...
+    def __call__(self, t: npt.NDArray[np.float64]) -> npt.NDArray[np.complex128]: ...
 
     def __call__(
-        self, t: float | npt.NDArray[np.float_]
-    ) -> complex | npt.NDArray[np.complex_]:
+        self, t: float | npt.NDArray[np.float64]
+    ) -> complex | npt.NDArray[np.complex128]:
         r"""
         The function :math:`z(t) = a + (b-a)t`.
 
@@ -365,11 +365,11 @@ class ComplexLine(ComplexPath):
     def dzdt(self, t: float) -> complex: ...
 
     @overload
-    def dzdt(self, t: npt.NDArray[np.float_]) -> npt.NDArray[np.complex_]: ...
+    def dzdt(self, t: npt.NDArray[np.float64]) -> npt.NDArray[np.complex128]: ...
 
     def dzdt(
-        self, t: float | npt.NDArray[np.float_]
-    ) -> complex | npt.NDArray[np.complex_]:
+        self, t: float | npt.NDArray[np.float64]
+    ) -> complex | npt.NDArray[np.complex128]:
         """
         The derivative of the parameterised curve in the complex plane, z, with
         respect to the parameterization parameter, t.
@@ -434,11 +434,11 @@ class ComplexArc(ComplexPath):
     def __call__(self, t: float) -> complex: ...
 
     @overload
-    def __call__(self, t: npt.NDArray[np.float_]) -> npt.NDArray[np.complex_]: ...
+    def __call__(self, t: npt.NDArray[np.float64]) -> npt.NDArray[np.complex128]: ...
 
     def __call__(
-        self, t: float | npt.NDArray[np.float_]
-    ) -> complex | npt.NDArray[np.complex_]:
+        self, t: float | npt.NDArray[np.float64]
+    ) -> complex | npt.NDArray[np.complex128]:
         r"""
         The function :math:`z(t) = R e^{i(t_0 + t dt)} + z_0`.
 
@@ -458,11 +458,11 @@ class ComplexArc(ComplexPath):
     def dzdt(self, t: float) -> complex: ...
 
     @overload
-    def dzdt(self, t: npt.NDArray[np.float_]) -> npt.NDArray[np.complex_]: ...
+    def dzdt(self, t: npt.NDArray[np.float64]) -> npt.NDArray[np.complex128]: ...
 
     def dzdt(
-        self, t: float | npt.NDArray[np.float_]
-    ) -> complex | npt.NDArray[np.complex_]:
+        self, t: float | npt.NDArray[np.float64]
+    ) -> complex | npt.NDArray[np.complex128]:
         """
         The derivative of the parameterised curve in the complex plane, z, with
         respect to the parameterization parameter, t.

--- a/cxroots/root_approximation.py
+++ b/cxroots/root_approximation.py
@@ -131,8 +131,8 @@ def approximate_roots(
 
         @overload
         def func(
-            z: npt.NDArray[np.complex_] | npt.NDArray[np.float_],
-        ) -> npt.NDArray[np.complex_] | complex: ...
+            z: npt.NDArray[np.complex128] | npt.NDArray[np.float64],
+        ) -> npt.NDArray[np.complex128] | complex: ...
 
         def func(z: ScalarOrArray) -> ComplexScalarOrArray:
             return phi(1)(z) * phi(i)(z)

--- a/cxroots/root_counting.py
+++ b/cxroots/root_counting.py
@@ -175,8 +175,8 @@ def _quad_prod(
 
     @overload
     def integrand_func(
-        z: npt.NDArray[np.complex_] | npt.NDArray[np.float_],
-    ) -> npt.NDArray[np.complex_] | complex: ...
+        z: npt.NDArray[np.complex128] | npt.NDArray[np.float64],
+    ) -> npt.NDArray[np.complex128] | complex: ...
 
     def integrand_func(z: ScalarOrArray) -> ComplexScalarOrArray:
         return phi(z) * psi(z) * (df(z) / f(z)) / (2j * pi)

--- a/cxroots/types.py
+++ b/cxroots/types.py
@@ -5,8 +5,10 @@ import numpy.typing as npt
 
 IntegrationMethod = Literal["quad", "romb"]
 Color = Union[str, tuple[float, float, float], tuple[float, float, float, float]]  # noqa: UP007
-ScalarOrArray = Union[complex, float, npt.NDArray[np.complex_], npt.NDArray[np.float_]]  # noqa: UP007
-ComplexScalarOrArray = Union[complex, npt.NDArray[np.complex_]]  # noqa: UP007
+ScalarOrArray = Union[  # noqa: UP007
+    complex, float, npt.NDArray[np.complex128], npt.NDArray[np.float64]
+]
+ComplexScalarOrArray = Union[complex, npt.NDArray[np.complex128]]  # noqa: UP007
 
 
 class AnalyticFunc(Protocol):
@@ -15,7 +17,7 @@ class AnalyticFunc(Protocol):
 
     @overload
     def __call__(
-        self, z: npt.NDArray[np.complex_] | npt.NDArray[np.float_]
+        self, z: npt.NDArray[np.complex128] | npt.NDArray[np.float64]
     ) -> ComplexScalarOrArray:
         # Note that the function may return a scalar in this case if, for example,
         # it's a constant function

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 #
 
 scipy==1.14.0
-numpy==1.26.4
+numpy==2.0.1
 numpydoc==1.7.0
 mpmath==1.3.0
 rich==13.7.1

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     python_requires=">=3.10",
     setup_requires=["pytest-runner"],
     install_requires=[
-        "numpy<2",
+        "numpy",
         "scipy",
         "numpydoc",
         "mpmath",


### PR DESCRIPTION
This PR simply replaces the usage of the deprecated numpy types `np.float_` and `np.complex_` with `np.float64` and `np.complex128`. This seems to be sufficient to obtain compatibility with numpy 2.0.1.